### PR TITLE
小節をまたぐ場合のエラーに情報追加

### DIFF
--- a/src/MML2NEUTRINO/MusicXMLGenerator.cs
+++ b/src/MML2NEUTRINO/MusicXMLGenerator.cs
@@ -70,7 +70,7 @@ namespace MML2NEUTRINO
                     }else if (mDuration > maxDuration)
                     {
                         string mml = CreateMML(elements, i);
-                        throw new FormatException(mml + " 小節をまたぐ音符が指定されています。");
+                        throw new FormatException($"{mml} 小節をまたぐ音符が指定されています。(over: {mDuration - maxDuration}/{maxDuration})");
                     }
                 }
                 else if(t == typeof(Rest))
@@ -87,7 +87,7 @@ namespace MML2NEUTRINO
                     else if (mDuration > maxDuration)
                     {
                         string mml = CreateMML(elements, i);
-                        throw new FormatException(mml + " 小節をまたぐ休符が指定されています。");
+                        throw new FormatException($"{mml} 小節をまたぐ休符が指定されています。(over: {mDuration - maxDuration}/{maxDuration})");
                     }
                 }
                 else if(t == typeof(Tempo))


### PR DESCRIPTION
単にオーバーしたよりも、何デュレーションオーバーしてるか表示した方が修正しやすいと思います。